### PR TITLE
Update installGci

### DIFF
--- a/bin/private/installGci
+++ b/bin/private/installGci
@@ -105,7 +105,7 @@ case "$clientType" in
         esac
         targetLocation="${directoryPath}"
         if [ ! -e "$targetLocation/msvcr*.dll" ] ; then
-          cp "${sourceLocation}/msvcr*" $targetLocation
+          cp "${sourceLocation}/msvcr"* $targetLocation
         else
           echo "[Warning]  ${sourceLocation}/msvcrXXX.dll already present to replace, delete and try again"
         fi


### PR DESCRIPTION
Fixed "cp: cannot stat"-bug when trying to copy windows DLLs while installing a client.